### PR TITLE
Fix the old course directory path used in no_sandbox.sh

### DIFF
--- a/scripts/no_sandbox.sh
+++ b/scripts/no_sandbox.sh
@@ -31,6 +31,13 @@ fi
 
 cd `dirname $0`/..
 ROOT=`pwd`
+
+if [ -d "$ROOT/exercises" ]; then
+    CDIR=exercises
+else
+    CDIR=courses
+fi
+
 CMD=
 
 # Working dir.
@@ -40,7 +47,7 @@ else
     cd /tmp
 fi
 
-export PATH=".:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:$ROOT/scripts/sandbox:$ROOT/exercises/$6/sandbox"
+export PATH=".:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:$ROOT/scripts/sandbox:$ROOT/$CDIR/$6/sandbox"
 
 # Limit process.
 function parse_size


### PR DESCRIPTION
In the past, courses were installed under the exercises directory of
the mooc-grader, but the directory was then renamed to courses.
`scripts/no_sandbox.sh` has been using the old path when it sets the `PATH` of the process, but this PR fixes that.