### PR TITLE
Add active elements

### DIFF
--- a/access/templates/access/accept_general_default.html
+++ b/access/templates/access/accept_general_default.html
@@ -1,0 +1,19 @@
+{% extends 'access/exercise_frame.html' %}
+{% load i18n %}
+
+
+{% block exercise %}
+{% if not result.error %}
+{% if exercise.instructions %}
+<div class="instructions">
+  {{ exercise.instructions|safe }}
+</div>
+{% else %}
+<h1>{% trans "Enter your submission" %}</h1>
+{% endif %}
+
+{% include 'access/personalized_content_default.html' %}
+
+{% include 'access/accept_general_form.html' %}
+{% endif %}
+{% endblock %}

--- a/access/templates/access/accept_general_form.html
+++ b/access/templates/access/accept_general_form.html
@@ -1,0 +1,46 @@
+{% load i18n %}
+{% if exercise.fields or exercise.files %}
+<form method="post" action="{{ post_url }}" enctype="multipart/form-data">
+
+	{% if exercise.fields %}
+	{% for entry in exercise.fields %}
+	<div class="form-group{% if entry.missing %} has-error{% endif %}">
+		<label for="{{ entry.name }}_id" class="control-label">
+			{{ entry.title|safe }}
+		</label>
+		{% if entry.more %}
+		{{ entry.more|safe }}
+		{% endif %}
+		<textarea id="{{ entry.name }}_id" name="{{ entry.name }}" class="form-control" rows="{% if entry.rows %}{{ entry.rows }}{% else %}6{% endif %}"></textarea>
+	</div>
+	{% endfor %}
+	{% endif %}
+
+	{% if exercise.files %}
+
+		{% if exercise.required_number_of_files %}
+			<p>
+			{% blocktrans with num_files=exercise.required_number_of_files %}
+				Submit only {{ num_files }} of the following files.
+			{% endblocktrans %}
+			</p>
+		{% endif %}
+
+		{% for entry in exercise.files %}
+		<div class="form-group">
+			<label for="{{ entry.field }}_id">
+				<span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+				{{ entry.name }}
+			</label>
+			<input type="file" id="{{ entry.field }}_id" name="{{ entry.field }}" class="form-control" />
+		</div>
+		{% endfor %}	
+	{% endif %}
+
+	{% if post_url or not result.accepted %}
+	<div class="form-group">
+		<input type="submit" value="{% trans 'Submit' %}" class="btn btn-primary aplus-submit" />
+	</div>
+	{% endif %}
+</form>
+{% endif %}

--- a/access/templates/access/active_element_default.html
+++ b/access/templates/access/active_element_default.html
@@ -1,0 +1,34 @@
+{% extends 'frame.html' %}
+{% load i18n %}
+
+{% block head %}
+{% include 'access/exercise_head.html' %}
+{% endblock %}
+
+{% block body %}
+<div id="exercise">
+
+
+
+	{% if result.error %}
+	<div class="alert alert-danger">
+
+		{% if result.invalid_address %}
+		<p>{% trans "Invalid address entered." %}</p>
+		{% endif %}
+
+		{% if result.nonce_used %}
+		<p>{% trans "The same form can obly be submitted once. Start again from exercise description." %}</p>
+		{% endif %}
+
+		{% if result.fields %}
+		<p>{% trans "Missing required fields." %}</p>
+		{% endif %}
+
+	</div>
+	{% endif %}
+
+  <div class="ae_result form-control" data-expected-inputs="{% for field in exercise.fields %}{{ field.name }} {% endfor %}{% for file in exercise.files %}{{ file.field }} {% endfor %}"></div>
+
+</div>
+{% endblock %}

--- a/access/templates/access/active_element_feedback.html
+++ b/access/templates/access/active_element_feedback.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+<div id="feedback">
+	{% for entry in result.tests %}
+	{% if entry.title or entry.out or entry.err or entry.points > 0 %}
+		{% if entry.title %}
+		<h3>{{ entry.title }}</h3>
+		{% endif %}
+
+		{% if entry.points > 0 and entry.max_points > 0 %}
+		{% blocktrans with points=entry.points max_points=entry.max_points %}
+		Points {{ points }}/{{ max_points }}
+		{% endblocktrans %}
+		{% endif %}
+
+		{% if entry.out %}
+		{% if entry.html %}
+		{{ entry.out|safe }}
+		{% else %}
+		  <pre>{{ entry.out }}</pre>
+		{% endif %}
+		{% endif %}
+
+		{% if entry.err %}
+		<pre class="alert alert-danger">{{ entry.err }}</pre>
+		{% endif %}
+	{% endif %}
+	{% endfor %}
+</div>

--- a/access/types/stdasync.py
+++ b/access/types/stdasync.py
@@ -264,6 +264,70 @@ def acceptGitUser(request, course, exercise, post_url):
         })
 
 
+def acceptGeneralForm(request, course, exercise, post_url):
+    '''
+    Presents a template and accepts form containing any input types 
+    (text, file, etc) for grading queue.
+    '''
+
+    _requireActions(exercise)
+    if not_modified_since(request, exercise):
+        return not_modified_response(request, exercise)
+
+    fields = copy.deepcopy(exercise.get("fields", []))
+    result = None
+    miss = False
+    
+    if request.method == "POST":
+        # Parse submitted values.
+        for entry in fields:        
+            entry["value"] = request.POST.get(entry["name"], "").strip()
+            if "required" in entry and entry["required"] and not entry["value"]:
+                entry["missing"] = True
+                miss = True
+        
+        files_submitted = [] 
+        if "files" in exercise:
+            # Confirm that all required files were submitted.
+            #files_submitted = [] # exercise["files"] entries for the files that were really submitted
+            for entry in exercise["files"]:
+                # by default, all fields are required
+                required = ("required" not in entry or entry["required"])
+                if entry["field"] not in request.FILES:
+                    if required:
+                        result = { "rejected": True, "missing_files": True }
+                        break
+                else:
+                    files_submitted.append(entry)
+                   
+        if miss:
+            result = { "fields": fields, "rejected": True }
+        elif result is None:
+            # Store submitted values.
+            sdir = create_submission_dir(course, exercise)
+            for entry in fields:
+                write_submission_file(sdir, entry["name"], entry["value"])
+                               
+            if "files" in exercise:
+                if "required_number_of_files" in exercise and \
+                        exercise["required_number_of_files"] > len(files_submitted):
+                    result = { "rejected": True, "missing_files": True }
+                else:
+                    # Store submitted files.
+                    for entry in files_submitted:
+                        save_submitted_file(sdir, entry["name"], request.FILES[entry["field"]])             
+            return _acceptSubmission(request, course, exercise, post_url, sdir)
+    
+    return cache_headers(
+        render_configured_template(
+            request, course, exercise, post_url,
+            "access/accept_general_default.html", result
+        ),
+        request,
+        exercise
+    )    
+
+
 def _requireActions(exercise):
     '''
     Checks that some actions are set.

--- a/courses/README.md
+++ b/courses/README.md
@@ -188,7 +188,16 @@ course specific exercise view in a course specific Python module.
 		(Format is used by A+ exercises with attachments).
 	* `accepted_message` etc as in type 1.
 
-5. ### access.types.stdsync.createForm
+5. ### access.types.stdsync.acceptGeneralForm
+  Accepts a general form submission (can also include files) asynchronous 
+  grading queue. Extended attributes:
+	* `files`: list of expected files as in type 1
+	* `fields`: list of text fields as in type 2
+	* `template` (default `access/accept_general_default.html`):
+		name of a template to present
+	* `accepted_message` etc as in type 1.
+			
+6. ### access.types.stdsync.createForm
 	Synchronous form checker. Requires `max_points` in the
 	exercise configuration. If form has no points configured then maximum
 	points are granted on errorless submission. Extended attributes:
@@ -232,7 +241,7 @@ course specific exercise view in a course specific Python module.
 	* `accepted_message` (optional): overrides the default message displayed when
 		submission is accepted
 
-6. ### access.types.stdsync.comparePostValues
+7. ### access.types.stdsync.comparePostValues
 	Synchronous check against posted values. Requires `max_points` in the
 	exercise configuration. If values have no points configured then maximum
 	points are granted on errorless submission. Extended attributes:
@@ -243,7 +252,7 @@ course specific exercise view in a course specific Python module.
 	* `template`: name of a template to present. Template should manually
 		include a form that produces the expected POST values.
 
-7. ### access.types.stdsync.noGrading
+8. ### access.types.stdsync.noGrading
 	Presents a template and does not grade anything. Extended attributes:
 	* `template`: name of a template to present
 


### PR DESCRIPTION
Adds view type and templates for active elements. The view type acceptGeneralForm is effectively a combination of acceptPost and acceptFiles and should be able to handle general form submits that include files, text inputs and dropdowns (other input types not tested). The default template for the type currently creates a text input for any other input than file.