### PR TITLE
Languages

### DIFF
--- a/access/config.py
+++ b/access/config.py
@@ -152,6 +152,9 @@ class ConfigParser:
         if not exercise_root or "data" not in exercise_root or not exercise_root["data"]:
             return course_root["data"], None
 
+        if lang == '_root':
+            return course_root["data"], exercise_root["data"]
+
         # Try to find version for requested or configured language.
         for lang in (lang, course_root["lang"]):
             if lang in exercise_root["data"]:
@@ -510,9 +513,9 @@ class ConfigParser:
             else:
                 return n
 
-        default = recursion(data, DEFAULT_LANG, True)
+        default = recursion(data, default_lang, True)
         root = { default_lang: default }
-        for lang in set(lang_keys) - set([DEFAULT_LANG]):
+        for lang in (set(lang_keys) - set([default_lang])):
             root[lang] = recursion(data, lang)
 
         LOGGER.debug('Processed %d tags.', len(tags_processed))

--- a/access/config.py
+++ b/access/config.py
@@ -48,10 +48,9 @@ class ConfigParser:
         'json': json.load,
         'yaml': yaml.load
     }
-    PROCESSOR_TAG_REGEX_18N = re.compile(r'^.+\|i18n(\|.+)?$')
     PROCESSOR_TAG_REGEX = re.compile(r'^(.+)\|(\w+)$')
     TAG_PROCESSOR_DICT = {
-        'i18n': lambda root, parent, value, **kwargs: value[kwargs['lang']],
+        'i18n': lambda root, parent, value, **kwargs: value.get(kwargs['lang']),
         'rst': lambda root, parent, value, **kwargs: get_rst_as_html(value),
     }
 
@@ -154,7 +153,7 @@ class ConfigParser:
             return course_root["data"], None
 
         # Try to find version for requested or configured language.
-        for lang in lang, course_root["lang"]:
+        for lang in (lang, course_root["lang"]):
             if lang in exercise_root["data"]:
                 return course_root["data"], exercise_root["data"][lang]
 
@@ -205,9 +204,6 @@ class ConfigParser:
                 course_key
             )
 
-        if "language" in data:
-            data["lang"] = data["language"]
-
         if "modules" in data:
             keys = []
             config = {}
@@ -243,12 +239,21 @@ class ConfigParser:
             "mtime": t,
             "ptime": time.time(),
             "data": data,
-            "lang": data.get('lang', DEFAULT_LANG),
+            "lang": self._default_lang(data),
             "exercise_loader": exercise_loader,
             "exercises": {}
         }
         symbolic_link(DIR, data)
         return course_root
+
+
+    def _default_lang(self, data):
+        l = data.get('language')
+        if type(l) == list:
+            data['lang'] = l[0]
+        elif l == str:
+            data['lang'] = l
+        return data.get('lang', DEFAULT_LANG)
 
 
     def _exercise_root(self, course_root, exercise_key):
@@ -292,7 +297,7 @@ class ConfigParser:
             return None
 
         # Process key modifiers and create language versions of the data.
-        self._process_exercise_data(course_root, data)
+        data = self._process_exercise_data(course_root, data)
         for version in data.values():
             self._check_fields(f, version, ["title", "view_type"])
             version["key"] = exercise_key
@@ -479,41 +484,39 @@ class ConfigParser:
         @type data: C{dict}
         @param data: a config data dictionary to process (in-place)
         '''
+        default_lang = course_root['lang']
+        lang_keys = []
+        tags_processed = []
 
-        # Create a deep copy of data for each intercepted language.
-        lang_root = {}
-        for k, v, p in iterate_kvp_with_dfs(data, key_regex=self.PROCESSOR_TAG_REGEX_18N):
-            for lang in v.keys():
-                if lang not in lang_root:
-                    lang_root[lang] = copy.deepcopy(data)
-        default_lang = course_root["lang"]
-        if not default_lang in lang_root:
-            lang_root[default_lang] = copy.deepcopy(data)
+        def recursion(n, lang, collect_lang=False):
+            t = type(n)
+            if t == dict:
+                d = {}
+                for k,v in n.items():
+                    m = self.PROCESSOR_TAG_REGEX.match(k)
+                    while m:
+                        k, tag = m.groups()
+                        tags_processed.append(tag)
+                        if collect_lang and tag == 'i18n' and type(v) == dict:
+                            lang_keys.extend(v.keys())
+                        if tag not in self.TAG_PROCESSOR_DICT:
+                            raise ConfigError('Unsupported processor tag "%s"' % (tag))
+                        v = self.TAG_PROCESSOR_DICT[tag](d, n, v, lang=lang)
+                        m = self.PROCESSOR_TAG_REGEX.match(k)
+                    d[k] = recursion(v, lang, collect_lang)
+                return d
+            elif t == list:
+                return [recursion(v, lang, collect_lang) for v in n]
+            else:
+                return n
 
-        LOGGER.debug('Found %d language versions: %s', len(lang_root), list(lang_root.keys()))
+        default = recursion(data, DEFAULT_LANG, True)
+        root = { default_lang: default }
+        for lang in set(lang_keys) - set([DEFAULT_LANG]):
+            root[lang] = recursion(data, lang)
 
-        # Replace data with the language versions.
-        data.clear()
-        data.update(lang_root)
-
-        # Apply processor flag transformations for data.
-        tags_processed_count = 0
-        for lang, lang_data in data.items():
-            for k, v, p in iterate_kvp_with_dfs(lang_data, key_regex=self.PROCESSOR_TAG_REGEX):
-
-                # Multiple processor flags may be combined.
-                match = self.PROCESSOR_TAG_REGEX.match(k)
-                while match:
-                    del p[k]
-                    k, tag = match.groups()
-                    if tag not in self.TAG_PROCESSOR_DICT:
-                        raise ConfigError('Unsupported processor tag "%s"' % (tag))
-                    p[k] = v = self.TAG_PROCESSOR_DICT[tag](lang_data, p, v, lang=lang)
-
-                    tags_processed_count += 1
-                    match = self.PROCESSOR_TAG_REGEX.match(k)
-
-        LOGGER.debug('Processed %d tags.', tags_processed_count)
+        LOGGER.debug('Processed %d tags.', len(tags_processed))
+        return root
 
 
 # An object that holds on to the latest exercise configuration.

--- a/access/tests.py
+++ b/access/tests.py
@@ -25,6 +25,11 @@ class ConfigTestCase(TestCase):
     def setUp(self):
         self.config = ConfigParser()
 
+    def get_course_key(self):
+        courses = self.config.courses()
+        self.assertGreater(len(courses), 0, "No courses configured")
+        return courses[0]['key']
+
     def test_rst_parsing(self):
         from access.config import get_rst_as_html
         self.assertEqual(get_rst_as_html('A **foobar**.'), '<p>A <strong>foobar</strong>.</p>\n')
@@ -66,14 +71,8 @@ class ConfigTestCase(TestCase):
         self.assertGreater(root["mtime"], mtime)
         self.assertGreater(root["ptime"], ptime)
 
-
     def test_shell_invoke(self):
         r = invoke_script(settings.PREPARE_SCRIPT, {})
         self.assertEqual(1, r["code"])
         r = invoke_script(settings.PREPARE_SCRIPT, { "course_key": "foo", "dir": settings.SUBMISSION_PATH })
         self.assertEqual(0, r["code"])
-
-    def get_course_key(self):
-        courses = self.config.courses()
-        self.assertGreater(len(courses), 0, "No courses configured")
-        return courses[0]['key']

--- a/access/tests.py
+++ b/access/tests.py
@@ -2,6 +2,7 @@
 '''
 This module holds unit tests. It has nothing to do with the grader tests.
 '''
+import time, os
 from django.conf import settings
 from django.test import TestCase
 
@@ -11,37 +12,68 @@ from util.shell import invoke_script
 
 class ConfigTestCase(TestCase):
 
+    TEST_DATA = {
+        'key': 'value',
+        'title|i18n': {'en': 'A Title', 'fi': 'Eräs otsikko'},
+        'text|rst': 'Some **fancy** text with ``links <http://google.com>`` and code like ``echo "moi"``.',
+        'nested': {
+            'number|i18n': {'en': 1, 'fi': 2},
+            'another': 10
+        }
+    }
+
     def setUp(self):
         self.config = ConfigParser()
 
-    def test_parsing(self):
+    def test_rst_parsing(self):
         from access.config import get_rst_as_html
         self.assertEqual(get_rst_as_html('A **foobar**.'), '<p>A <strong>foobar</strong>.</p>\n')
-        import re
-        from access.config import iterate_kvp_with_dfs
-        data = {
-            'title|i18n': {'en': 'A Title', 'fi': 'Eräs otsikko'},
-            'text|rst': 'Some **fancy** text with ``links <http://google.com>`` and code like ``echo "moi"``.'
-        }
-        self.config._process_exercise_data({ "lang": "en" }, data)
+
+    def test_parsing(self):
+        course = { "lang": "en" }
+        data = self.config._process_exercise_data(course, self.TEST_DATA)
         self.assertEqual(data["en"]["text"], data["fi"]["text"])
         self.assertEqual(data["en"]["title"], "A Title")
+        self.assertEqual(data["en"]["nested"]["number"], 1)
         self.assertEqual(data["fi"]["title"], "Eräs otsikko")
+        self.assertEqual(data["fi"]["nested"]["number"], 2)
 
-    def test_loading(self):
-        courses = self.config.courses()
-        self.assertGreater(len(courses), 0, "No courses configured")
-        course_key = courses[0]["key"]
+    def test_cache(self):
+        course_key = self.get_course_key()
 
         root = self.config._course_root(course_key)
+        mtime = root["mtime"]
         ptime = root["ptime"]
+        self.assertGreater(ptime, mtime)
 
         # Ptime changes if cache is missed.
         root = self.config._course_root(course_key)
-        self.assertEqual(ptime, root["ptime"])
+        self.assertEqual(root["mtime"], mtime)
+        self.assertEqual(root["ptime"], ptime)
+
+    def test_cache_reload(self):
+        course_key = self.get_course_key()
+
+        root = self.config._course_root(course_key)
+        mtime = root["mtime"]
+        ptime = root["ptime"]
+        self.assertGreater(ptime, mtime)
+
+        time.sleep(1.5)
+        os.utime(root["file"])
+        root = self.config._course_root(course_key)
+        self.assertGreater(root["ptime"], root["mtime"])
+        self.assertGreater(root["mtime"], mtime)
+        self.assertGreater(root["ptime"], ptime)
+
 
     def test_shell_invoke(self):
         r = invoke_script(settings.PREPARE_SCRIPT, {})
         self.assertEqual(1, r["code"])
         r = invoke_script(settings.PREPARE_SCRIPT, { "course_key": "foo", "dir": settings.SUBMISSION_PATH })
         self.assertEqual(0, r["code"])
+
+    def get_course_key(self):
+        courses = self.config.courses()
+        self.assertGreater(len(courses), 0, "No courses configured")
+        return courses[0]['key']

--- a/access/views.py
+++ b/access/views.py
@@ -188,7 +188,7 @@ def aplus_json(request, course_key):
         for o in [o for o in parent["children"] if "key" in o]:
             of = _type_dict(o, course.get("exercise_types", {}))
             if "config" in of:
-                _, exercise = config.exercise_entry(course["key"], str(of["key"]))
+                _, exercise = config.exercise_entry(course["key"], str(of["key"]), '_root')
                 of = export.exercise(request, course, exercise, of)
             elif "static_content" in of:
                 of = export.chapter(request, course, of)

--- a/access/views.py
+++ b/access/views.py
@@ -9,7 +9,7 @@ import copy
 import os
 import json
 
-from access.config import config
+from access.config import config, DEFAULT_LANG
 from util.files import read_and_remove_submission_meta, clean_submission_dir
 from util.queue import queue_length as qlength
 from util.http import post_data
@@ -73,10 +73,7 @@ def exercise(request, course_key, exercise_key):
 
     # Exercise language.
     if not lang:
-        if "lang" in course:
-            lang = course["lang"]
-        else:
-            lang = "en"
+        lang = course.get('lang', DEFAULT_LANG)
     translation.activate(lang)
 
     # Try to call the configured view.
@@ -181,6 +178,8 @@ def aplus_json(request, course_key):
     data = _copy_fields(course, ["name", "description", "lang", "contact",
         "assistants", "start", "end", "categories",
         "numerate_ignoring_modules"])
+    if "language" in course:
+        data["lang"] = course["language"]
 
     def children_recursion(parent):
         if not "children" in parent:


### PR DESCRIPTION
Refactor the old config modifiers that used to vanish a key on multilingual course configuration after running a while. This one recursively creates new dicts instead of manipulating by references. Additionally, add support to include configured language versions in json export as supported in a-plus.