### PR TITLE
Improve the pregenerate_exercises command

### DIFF
--- a/access/management/commands/pregenerate_exercises.py
+++ b/access/management/commands/pregenerate_exercises.py
@@ -3,9 +3,12 @@ import glob
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from access.views import config
-from util.personalized import delete_pregenerated_exercise_instances, \
-    prepare_pregenerated_exercises_directory, generate_exercise_instances, \
-    pregenerated_exercise_instances
+from util.personalized import (
+    delete_pregenerated_exercise_instances,
+    generate_exercise_instances,
+    pregenerated_exercise_instances,
+    prepare_pregenerated_exercises_directory,
+)
 
 class Command(BaseCommand):
     help = "Pregenerate personalized exercise instances"
@@ -46,7 +49,7 @@ class Command(BaseCommand):
             # take only personalized exercises
             exercises = list(filter(lambda ex: "personalized" in ex and ex["personalized"], exercises))
             if not exercises:
-                self.stderr.write("The course %s has no personalized exercises so no instances are generated." % (course_key))
+                self.stdout.write(self.style.WARNING("The course %s has no personalized exercises so no instances are generated." % (course_key)))
                 return
         
         # course and exercises have been parsed

--- a/access/management/commands/pregenerate_exercises.py
+++ b/access/management/commands/pregenerate_exercises.py
@@ -4,7 +4,8 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from access.views import config
 from util.personalized import delete_pregenerated_exercise_instances, \
-    prepare_pregenerated_exercises_directory, generate_exercise_instances
+    prepare_pregenerated_exercises_directory, generate_exercise_instances, \
+    pregenerated_exercise_instances
 
 class Command(BaseCommand):
     help = "Pregenerate personalized exercise instances"
@@ -20,6 +21,9 @@ class Command(BaseCommand):
                             help="Number of instances to generate for an exercise")
         parser.add_argument("--keep-old", action="store_true", dest="keep_old", default=False,
                             help="Keep existing generated instances instead of deleting them first")
+        parser.add_argument("--gen-if-none-exist", action="store_true", dest="gen_if_none_exist",
+                            default=False,
+                            help="Only generate new instances if no instances exist yet")
     
     def handle(self, *args, **options):
         course_key = options["course_key"]
@@ -42,7 +46,8 @@ class Command(BaseCommand):
             # take only personalized exercises
             exercises = list(filter(lambda ex: "personalized" in ex and ex["personalized"], exercises))
             if not exercises:
-                raise CommandError("The course %s has no personalized exercises" % (course_key))
+                self.stderr.write("The course %s has no personalized exercises so no instances are generated." % (course_key))
+                return
         
         # course and exercises have been parsed
         if options["instances"] < 1:
@@ -50,6 +55,10 @@ class Command(BaseCommand):
         
         try:
             for ex in exercises:
+                if options["gen_if_none_exist"] and pregenerated_exercise_instances(course, ex):
+                    # some instances already exist so do not delete them and do not generate any new instances
+                    continue
+                
                 if not options["keep_old"]:
                     delete_pregenerated_exercise_instances(course, ex)
                     # check if there are any users that had accessed any of the old, deleted instances


### PR DESCRIPTION
This small improvement is especially useful for the run-mooc-grader container.

Do not raise an exception if the given course has no personalized exercises;
the command can then be run with all courses without crashing.

Add an option to only generate new instances if none exist yet.
This allows the run-mooc-grader container to use the command and
still preserve any previously generated and stored instances.