### PR TITLE
use course key as cwd for generator cmd by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ scripts/chroot_execvp
 
 .DS_Store
 *~
+venv

--- a/courses/README.md
+++ b/courses/README.md
@@ -98,8 +98,12 @@ Durations are given in (int)(unit), where units are y, m, d, h or w.
 		   of the generated file
 		* `allow_download`: if true, the generated file can be downloaded from the web
 	* `generator`: (required if personalized) settings for the generator program that
-		creates one new instance of the exercise. At least `cmd` must be set.
+		creates one new instance of the exercise. At least `cmd` must be set. The generator
+		cmd will be run from course_key dir (course_key is the cwd).
 		* `cmd`: command line as an ARRAY that is used to run the generator.
+			Eg. ["generator_script.sh"] will run generator_script.sh from course_key dir
+			and ["python3", "script_dir/generator.py"] will run generator.py from
+			course_key/script_dir but keep course_key as cwd.
 			Mooc-grader appends the instance directory path to the argument list and
 			the generator is expected to write files into the directory. The file names
 			should be listed under `generated_files` setting so that mooc-grader is aware
@@ -107,8 +111,9 @@ Durations are given in (int)(unit), where units are y, m, d, h or w.
 			`python manage.py pregenerate_exercises course_key <exercise_key>`
 			(`--help` option prints all possible arguments).
 		* `cwd`: if set, this sets the current working directory for the generator
-			program. Start the path from the course directory (course key as the
-			first directory).
+			program. Since the default cwd is course_key, this applies to directories
+			in course_key. Eg. cwd: "script_dir" will change the cwd to course_key/script_dir
+			and only after that run cmd.
 	* `max_submissions_before_regeneration`: (optional, only usable in personalized exercises)
 		defines how many times the student may submit before the personalized exercise is
 		regenerated (the exercise instance is changed to another one). If unset,

--- a/util/personalized.py
+++ b/util/personalized.py
@@ -206,12 +206,13 @@ def generate_one_exercise_instance(course, exercise, dir_path):
         raise access.config.ConfigError(
                 'Missing "generator" and/or "cmd" under "generator" in the exercise configuration %s/%s' %
                 (course["key"], exercise["key"]))
-    
-    cwd = None
+
+    # default cwd is the course directory
+    cwd = os.path.join(access.config.DIR, course["key"])
     if "cwd" in exercise["generator"]:
-        # cwd path in the exercise config should start from the course directory
-        cwd = os.path.join(access.config.DIR, exercise["generator"]["cwd"])
-    
+        # if cwd is set, it should reside inside course directory
+        cwd = os.path.join(cwd, exercise["generator"]["cwd"])
+
     command = exercise["generator"]["cmd"][:] # copy the command list from config before appending
     command.append(dir_path)
     return invoke(command, cwd)


### PR DESCRIPTION
This change makes it possible for pregenerating personalized exercises both in local environment powered by course-templates docker/docker-compose setup *and* in production environment.

When the course is developed locally, it is located in mooc-grader file system in courses/default. When the course is deployed to production mooc-grader server, the location is almost certainly different, for instance courses/wsd-2018. Because the paths are different the "cwd" parameter of "generator" in exercise.yml doesn't help, it would need to be rewritten depending on the environment.

My proposal changes the behaviour of **_manage.py pregenerate_exercises <course_key>_** so that the "cmd" of "generator" will be executed from courses/<course_key>, not from the mooc-grader's root path where manage.py resides.