### PR TITLE
Add lang field to GradedForm

### DIFF
--- a/access/config.py
+++ b/access/config.py
@@ -158,7 +158,9 @@ class ConfigParser:
         # Try to find version for requested or configured language.
         for lang in (lang, course_root["lang"]):
             if lang in exercise_root["data"]:
-                return course_root["data"], exercise_root["data"][lang]
+                exercise = exercise_root["data"][lang]
+                exercise["lang"] = lang
+                return course_root["data"], exercise
 
         # Fallback to any existing language version.
         return course_root["data"], list(exercise_root["data"].values())[0]

--- a/access/templates/access/graded_form.html
+++ b/access/templates/access/graded_form.html
@@ -8,6 +8,8 @@
 
 		{% if field.field.type == "static" %}
 		{{ field.field.more|safe }}
+		{% elif field.field.type == "hidden" %}
+			{{ field }}
 		{% else %}
 
 		{% if not field.field.row_label or field.field.open_table %}

--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -142,6 +142,13 @@ class GradedForm(forms.Form):
 
             g += 1
 
+        if 'lang' in self.exercise:
+            self.add_field(i, {
+                'type': 'hidden',
+                'initial': self.exercise['lang'],
+                'key': '__grader_lang',
+            }, forms.CharField, forms.HiddenInput)
+
         # Protect sample used in a randomized form.
         if len(samples) > 0:
             self.nonce = random_ascii(16)
@@ -217,7 +224,8 @@ class GradedForm(forms.Form):
         field = field_class(**args)
         field.type = config['type']
         field.name = self.field_name(i, config)
-        field.label = mark_safe(config['title'])
+        if 'title' in config:
+            field.label = mark_safe(config['title'])
         field.more = self.create_more(config)
         field.points = config.get('points', 0)
         field.choice_list = not choices is None and widget_class != forms.Select

--- a/access/views.py
+++ b/access/views.py
@@ -64,7 +64,7 @@ def exercise(request, course_key, exercise_key):
     Presents the exercise and accepts answers to it.
     '''
     post_url = request.GET.get('post_url', None)
-    lang = request.GET.get('lang', None)
+    lang = request.POST.get('__grader_lang', None) or request.GET.get('lang', None)
     (course, exercise, lang) = _get_course_exercise_lang(course_key, exercise_key, lang)
 
     # Try to call the configured view.


### PR DESCRIPTION
and add a special case for hidden fields in graded_form.html.
Get language from POST if available.

This handles the language mismatch bug in every case that applies to O1,
except for the piazza exercise. Because whether A+ loads the previous submission
is decided by the course material and not grader, it is almost impossible to
fix the bug in general.