### PR TITLE
Fix ignorews option to ignore all whitespace, not just spaces

### DIFF
--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -353,7 +353,7 @@ class GradedForm(forms.Form):
 
         if "ignorews" in mods or t == "unsortedchars":
             def strip_ws(v):
-                return v.replace(" ","")
+                return ''.join(v.split())
             val = strip_ws(val)
             cmp = strip_ws(cmp)
 


### PR DESCRIPTION
In questionnaires freetext-questions ignorews-option previously only cleared spaces, but didn't do so to tabs or newlines. 