### PR TITLE
Don't show correct answer by default in the questionnaires

### DIFF
--- a/access/types/forms.py
+++ b/access/types/forms.py
@@ -34,6 +34,8 @@ class GradedForm(forms.Form):
         self.exercise = kwargs.pop("exercise")
         self.show_correct = kwargs.pop('show_correct') if 'show_correct' in kwargs else False
         self.show_correct_once = kwargs.pop('show_correct_once') if 'show_correct_once' in kwargs else False
+        if not self.exercise.get('reveal_model_at_max_submissions', False):
+            self.show_correct_once = False
         self.request = kwargs.pop('request') if 'request' in kwargs else None
         kwargs['label_suffix'] = ''
         super(forms.Form, self).__init__(*args, **kwargs)

--- a/courses/README.md
+++ b/courses/README.md
@@ -286,6 +286,9 @@ course specific exercise view in a course specific Python module.
 	* `template` (default `access/create_form_default.html`): name of a template to present
 	* `accepted_message` (optional): overrides the default message displayed when
 		submission is accepted
+	* `reveal_model_at_max_submissions` (optional): if false, the questionnaire feedback
+		does not reveal model solutions after the user has consumed all submission
+		attempts. By default false.
 
 7. ### access.types.stdsync.comparePostValues
 	Synchronous check against posted values. Requires `max_points` in the


### PR DESCRIPTION
Add `show_correct_once` option to exercise configuration to show model answer
after the last submission.